### PR TITLE
feat: add `generate-token` env

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{py,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{yaml,yml,tf}]
+indent_style = space
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__/
 .idea
 .vscode/
 cover
+.charmhub.secret

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
-# Copyright 2024 Canonical Ltd.
+# Copyright 2024-2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
 [tox]
 no_package = True
 skip_missing_interpreters = True
-env_list = format, lint, static, unit
+env_list = fmt, lint, typecheck, unit
 min_version = 4.0.0
 
 [vars]
@@ -42,6 +42,14 @@ commands =
     ruff check {[vars]all_path}
     black --check --diff {[vars]all_path}
 
+[testenv:typecheck]
+description = Run static type checks
+deps =
+    pyright
+    -r {tox_root}/requirements.txt
+commands =
+    pyright {posargs}
+
 [testenv:unit]
 description = Run unit tests
 deps =
@@ -51,22 +59,15 @@ deps =
     -r {tox_root}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-                 -m pytest \
-                 --tb native \
-                 -v \
-                 -s \
-                 {posargs} \
-                 {[vars]tests_path}/unit
+        -m pytest \
+        --tb native \
+        -v \
+        -s \
+        {posargs} \
+        {[vars]tests_path}/unit
     coverage report
     coverage xml -o cover/coverage.xml
 
-[testenv:static]
-description = Run static type checks
-deps =
-    pyright
-    -r {tox_root}/requirements.txt
-commands =
-    pyright {posargs}
 
 [testenv:integration]
 description = Run integration tests
@@ -75,8 +76,22 @@ deps =
     -r {tox_root}/requirements.txt
 commands =
     pytest -v \
-           -s \
-           --tb native \
-           --log-cli-level=INFO \
-           {posargs} \
-           {[vars]tests_path}/integration
+        -s \
+        --tb native \
+        --log-cli-level=INFO \
+        {posargs} \
+        {[vars]tests_path}/integration
+
+[testenv:generate-token]
+description = Generate Charmhub access token
+allowlist_externals =
+    /snap/bin/charmcraft
+commands =
+    charmcraft login --export .charmhub.secret \
+        --permission=package-manage-metadata \
+        --permission=package-manage-releases \
+        --permission=package-manage-revisions \
+        --permission=package-view-metadata \
+        --permission=package-view-releases \
+        --permission=package-view-revisions \
+        --ttl=777600


### PR DESCRIPTION
This PR adopts `generate-token` from the Slurm charms repo to make it quicker + easier to generate access tokens for Charmhub after the secret expires.

### Misc.

This PR also adds a _.editorconfig_ file since not every editor has the same default style settings.  This way we have to worry less about inconsistent spacing in files such as _tox.ini_ and complimenting Terraform plans.